### PR TITLE
Non blocking option for using openfile

### DIFF
--- a/micview/__init__.py
+++ b/micview/__init__.py
@@ -12,13 +12,13 @@ def openfile(file: str, mask: str=None, resized: bool=False, block: bool=False) 
     if(resized):
         argv.append('-r')
 
-    import threading
+    from multiprocessing import Process
     from micview.run import main
 
     if block:
         main(argv)
     else:
-        daemon = threading.Thread(target=main, args=(argv,))
-        daemon.setDaemon(True)
+        daemon = Process(target=main, args=(argv,))
+        daemon.daemon = True
         daemon.start()
         


### PR DESCRIPTION
Acho que a micview já ta madura o suficiente pra começarmos a colocar em uso real, vai começar a chegar coisas de QA e external testing! haha

Percebi que seu openfile tava bloqueando e fiz uma modificação pequena pra ter uma opção de lançar sem bloquear o programa que ta usando a api.


Known issue (resolvido no comentário abaixo): 

Nos meus testes aqui, chamar no modo não block várias vezes e depois chamar em block (exemplo: vc quer abrir varias imagens ao mesmo tempo de vez, e bloquear na ultima call, um caso comum ao debugar multiplos volumes) aparece uns erros. Suspeito que seja algo com variáveis globais? 

Isso é um caso bem edge case e não precisa se preocupar em consertar isso agora, mas é uma coisa a se pensar como resolveria. É bem comum ao usar esses programas que o usuário abra vários ao mesmo tempo mexendo em várias imagens, e o problema parece ser relacionado a usar o mesmo interpretador pra chamar varias runs (modo de uso "api" em vez de CLI).